### PR TITLE
added business update and page

### DIFF
--- a/app/api/businesses/[id]/route.ts
+++ b/app/api/businesses/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db/db";
-import { BusinessesTable } from "@/lib/db/schema";
+import { Business, BusinessesTable } from "@/lib/db/schema";
 import { getUserFromToken } from "@/lib/auth";
 import { cookies } from "next/headers";
 import { eq, and } from "drizzle-orm";
@@ -115,7 +115,10 @@ export async function PUT(
     // validate id
     const businessId = parseInt(params.id);
     if (isNaN(businessId)) {
-      return NextResponse.json({ error: "Invalid business ID" }, { status: 400 });
+      return NextResponse.json(
+        { error: "Invalid business ID" },
+        { status: 400 }
+      );
     }
 
     // check existence

--- a/app/businesses/[id]/edit/page.tsx
+++ b/app/businesses/[id]/edit/page.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Business } from "@/lib/db/schema";
+import { BusinessForm } from "@/components/forms/business-form/business-form";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+
+export default function EditBusinessPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const [business, setBusiness] = useState<Business | null>(null);
+  const [loading, setLoading] = useState(true);
+  const router = useRouter();
+
+  useEffect(() => {
+    const fetchBusiness = async () => {
+      try {
+        const response = await fetch(`/api/businesses/${params.id}`);
+        if (!response.ok) {
+          throw new Error("Business not found");
+        }
+        const data = await response.json();
+        setBusiness(data);
+      } catch (error) {
+        console.error("Error fetching business details:", error);
+        router.push("/404"); // Redirect to a 404 page if business not found
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchBusiness();
+  }, [params.id, router]);
+
+  const handleUpdate = async (updatedBusiness: Partial<Business>) => {
+    try {
+      const response = await fetch(`/api/businesses/${params.id}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(updatedBusiness),
+      });
+
+      if (response.ok) {
+        router.push(`/businesses/${params.id}`);
+      } else {
+        const errorData = await response.json();
+        console.error("Failed to update business:", errorData.error);
+      }
+    } catch (error) {
+      console.error("Error updating business:", error);
+    }
+  };
+
+  if (loading) return <div>Loading...</div>;
+
+  if (!business) return <div>Business not found</div>;
+
+  return (
+    <div>
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-3xl font-bold">Edit Business</h1>
+        <Button asChild>
+          <Link href={`/businesses/${params.id}`}>Cancel</Link>
+        </Button>
+      </div>
+      <BusinessForm initialData={business} onSubmit={handleUpdate} />
+    </div>
+  );
+}

--- a/app/businesses/[id]/page.tsx
+++ b/app/businesses/[id]/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { PencilIcon } from "lucide-react";
+
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Business } from "@/lib/db/schema";
@@ -100,6 +102,12 @@ export default function BusinessDetailsPage({
       <div className="flex gap-2">
         <Button asChild>
           <Link href="/businesses">Back to Businesses</Link>
+        </Button>
+
+        <Button variant="outline" size="icon">
+          <Link href={`/businesses/${params.id}/edit`}>
+            <PencilIcon />
+          </Link>
         </Button>
 
         <Button variant="destructive" onClick={handleDelete}>

--- a/app/businesses/new/page.tsx
+++ b/app/businesses/new/page.tsx
@@ -1,8 +1,38 @@
+"use client";
+
 import { BusinessForm } from "@/components/forms/business-form/business-form";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
+import { Business } from "@/lib/db/schema";
+import { useRouter } from "next/navigation";
 
 export default function NewBusinessPage() {
+  const router = useRouter();
+
+  const handleCreate = async (newBusiness: Partial<Business>) => {
+    try {
+      const token = localStorage.getItem("token");
+      const response = await fetch("/api/businesses", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(newBusiness),
+      });
+
+      if (response.ok) {
+        console.log("Business added successfully");
+        router.push("/businesses");
+      } else {
+        const errorData = await response.json();
+        console.error("Failed to add business:", errorData.error);
+      }
+    } catch (error) {
+      console.error("An error occurred:", error);
+    }
+  };
+
   return (
     <div>
       <div className="flex justify-between items-center mb-6">
@@ -13,7 +43,7 @@ export default function NewBusinessPage() {
           </Button>
         </div>
       </div>
-      <BusinessForm />
+      <BusinessForm onSubmit={handleCreate} />
     </div>
   );
 }

--- a/components/forms/business-form/business-form.tsx
+++ b/components/forms/business-form/business-form.tsx
@@ -14,16 +14,24 @@ import { Business } from "@/lib/db/schema";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 
-export const BusinessForm: React.FC = () => {
+type BusinessFormProps = {
+  initialData?: Partial<Business>;
+  onSubmit: (businessData: Partial<Business>) => Promise<void>;
+};
+
+export const BusinessForm: React.FC<BusinessFormProps> = ({
+  initialData,
+  onSubmit,
+}) => {
   const router = useRouter();
   const [formData, setFormData] = useState<Partial<Business>>({
-    name: "",
-    address: "",
-    phoneNumber: "",
-    description: "",
-    hours: "",
-    email: "",
-    type: "",
+    name: initialData?.name || "",
+    address: initialData?.address || "",
+    phoneNumber: initialData?.phoneNumber || "",
+    description: initialData?.description || "",
+    hours: initialData?.hours || "",
+    email: initialData?.email || "",
+    type: initialData?.type || "",
   });
 
   const handleChange = (
@@ -45,27 +53,8 @@ export const BusinessForm: React.FC = () => {
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    try {
-      const token = localStorage.getItem("token");
-      const response = await fetch("/api/businesses", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify(formData),
-      });
 
-      if (response.ok) {
-        console.log("Business added successfully");
-        router.push("/businesses");
-      } else {
-        const errorData = await response.json();
-        console.error("Failed to add business:", errorData.error);
-      }
-    } catch (error) {
-      console.error("An error occurred:", error);
-    }
+    await onSubmit(formData);
   };
 
   return (

--- a/components/forms/business-form/business-form.tsx
+++ b/components/forms/business-form/business-form.tsx
@@ -11,7 +11,6 @@ import {
   SelectTrigger,
 } from "@/components/ui/select";
 import { Business } from "@/lib/db/schema";
-import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 
 type BusinessFormProps = {
@@ -23,7 +22,6 @@ export const BusinessForm: React.FC<BusinessFormProps> = ({
   initialData,
   onSubmit,
 }) => {
-  const router = useRouter();
   const [formData, setFormData] = useState<Partial<Business>>({
     name: initialData?.name || "",
     address: initialData?.address || "",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "migrate": "drizzle-kit push"
+    "migrate": "drizzle-kit push",
+    "pre-check": "tsc && pnpm lint"
   },
   "dependencies": {
     "@next/env": "^14.2.8",


### PR DESCRIPTION
Created functionality for business update:

- When user clicks on the pencil icon -> transfer to edit page
- Edit page pre-populates BusinessForm info from existing data
- Updates data on form submit with a PUT request

Main changes:

Moved the submit logic outside of BusinessForm into the respective pages, so onSubmit can be passed as a prop depending on which page it is used in.